### PR TITLE
add login.gov

### DIFF
--- a/SecurityChecklist.md
+++ b/SecurityChecklist.md
@@ -294,6 +294,7 @@ that you can maintain your identity with these providers.
 | **Account** |  **Purpose** | **Why this is important** | **Actions to take**|
 | ---- | ---- | ---- | ---- |
 |  [IRS.gov](https://www.irs.gov/payments/view-your-tax-account) | IRS online services account |  Identity theft prevention; as well as protecting your IRS account from someone else registering (and potentially submitting a tax return as you) | Use a strong and unique password (stored in your password manager of choice) and enable 2FA|
+| [login.gov](https://login.gov/) | login.gov | The long-term goal of login.gov is to be the centralized authentication provider for most US Federal websites. | Use a strong and unique password (stored in your password manager of choice) and enable 2FA|
 | [SSA.gov](https://www.ssa.gov/site/signin/en/) | my Social Security | Identity theft prevention; as well as protecting your Social Security account from someone else registering (and potentially claiming your social security benefits) | Use a strong and unique password (stored in your password manager of choice) and enable 2FA |
 | [USPS.com](https://www.usps.com/) | Informed Delivery | Sign up for Informed Delivery - to see what is coming in your mailbox; otherwise someone else could setup this account and would know if something sensitive is waiting in your mailbox or they could perform mail forwarding without your knowledge (helps to prevent identity theft) | Use a strong and unique password (stored in your password manager of choice) and enable 2FA|
 


### PR DESCRIPTION
Add login.gov. 

The site's own branding seems to prefer all lower case, so I've referred to it accordingly.